### PR TITLE
Consider managing repo settings via GitHub's probot app

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,10 @@
+# See: https://github.com/probot/settings#usage
+
+repository:
+  name: polisCode
+  default_branch: monorepo
+  description: :nut_and_bolt: nuts and bolts of the system
+  homepage: https://pol.is
+  has_issues: true
+  has_wiki: false
+  has_projects: false


### PR DESCRIPTION
GitHub has an app that we can auth on the repo and use to manage/sync repo settings through the PR process, just like we would with any code change. Can be nice way to change things using the same process everyone already understands: labels, branch protection, repo description, topics, collaborators, etc

App: https://github.com/apps/settings
Code: https://github.com/probot/settings

This just imports current settings into a config file, and doesn't change anything.

I'm mainly intending this as a check-in on whether this app would suit upstream `pol-is` org. I'm not intending this yet as a place to change settings, though that's certainly something to do later.

cc: @colinmegill @metasoarous

## To Do

- [ ] decide if this app is ok for upstream
- [ ] auth app against this repo https://github.com/apps/settings
- [ ] document (CONTRIBUTING.md?)
- [ ] merge PR